### PR TITLE
Recognize all English-based localizations.

### DIFF
--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -202,7 +202,7 @@ NSString * TTTLocalizedPluralStringKeyForCountAndSingularNoun(NSUInteger count, 
         pluralRule = TTTSimplifiedChinesePluralRuleForCount(count);
     } else if ([languageCode isEqualToString:@"cs"]) {
         pluralRule = TTTCzechPluralRuleForCount(count);
-    } else if ([languageCode isEqualToString:@"en"]) {
+    } else if ([languageCode hasPrefix:@"en"]) {
         pluralRule = TTTEnglishPluralRuleForCount(count);
     } else if ([languageCode isEqualToString:@"fr"]) {
         pluralRule = TTTFrenchPluralRuleForCount(count);


### PR DESCRIPTION
In addition to the generic top-level "en" localization, there are also
region-specific English localizations (such as "en-US" and "en-GB")
that should be recognized as English.
