### PR TITLE
Add traditional chinese plural rule

### DIFF
--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -57,6 +57,10 @@ static NSString * TTTSimplifiedChinesePluralRuleForCount(NSUInteger count) {
     return kTTTOtherPluralRule;
 }
 
+static NSString * TTTTraditionalChinesePluralRuleForCount(NSUInteger count) {
+    return kTTTOtherPluralRule;
+}
+
 static NSString * TTTCzechPluralRuleForCount(NSUInteger count) {
     switch (count) {
         case 1:
@@ -209,6 +213,8 @@ NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInte
         pluralRule = TTTArabicPluralRuleForCount(count);
     } else if ([languageCode hasPrefix:@"zh-Hans"]) {
         pluralRule = TTTSimplifiedChinesePluralRuleForCount(count);
+    } else if ([languageCode hasPrefix:@"zh-Hant"]) {
+        pluralRule = TTTTraditionalChinesePluralRuleForCount(count);
     } else if ([languageCode hasPrefix:@"cs"]) {
         pluralRule = TTTCzechPluralRuleForCount(count);
     } else if ([languageCode hasPrefix:@"en"]) {


### PR DESCRIPTION
This patch adds the traditional chinese plural rule according to Rules(http://unicode.org/cldr/charts/supplemental/language_plural_rules.html)
This is same as Simplified one
