### PR TITLE
Fixing an incorrect plural rule for Russian

### DIFF
--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -351,7 +351,7 @@ static NSString * TTTRussianPluralRuleForCount(NSUInteger count) {
                 case 11:
                     break;
                 default:
-                    return kTTTFewPluralRule;
+                    return kTTTOnePluralRule;
             }
 
             break;


### PR DESCRIPTION
According to http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html:

one → n mod 10 is 1 and n mod 100 is not 11;

The original mapped this to "few"
