### PR TITLE
Fix plural rule for french

### DIFF
--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -127,6 +127,7 @@ static NSString * TTTEnglishPluralRuleForCount(NSUInteger count) {
 static NSString * TTTFrenchPluralRuleForCount(NSUInteger count) {
     switch (count) {
         case 0:
+            return kTTTZeroPluralRule;
         case 1:
             return kTTTOnePluralRule;
         default:


### PR DESCRIPTION
I just noticed a bug in an app I'm working on that counts the number of comments on a post and realized it always showed "Un commentaire" even when there was no comments on the post yet.
Unless I don't understand what this lib does, this should fix it.
