### PR TITLE
get the pluralization key without formatting it

### DIFF
--- a/TTTLocalizedPluralString.h
+++ b/TTTLocalizedPluralString.h
@@ -23,13 +23,14 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * TTTLocalizedPluralStringKeyForCountAndSingularNoun(NSUInteger count, NSString *singular);
-extern NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInteger count, NSString *singular, NSString *languageCode);
+extern NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounUnformatted(NSUInteger count, NSString *singular);
+extern NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInteger count, NSString *singular, NSString *languageCode, BOOL formatted);
 
 #define TTTLocalizedPluralString(count, singular, comment) \
 [NSString stringWithFormat:[[NSBundle mainBundle] localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNoun(count, singular) value:@"" table:nil], count]
 
 #define TTTLocalizedPluralStringForLanguage(count, singular, languageCode) \
-[NSString stringWithFormat:[[NSBundle mainBundle] localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode) value:@"" table:nil], count]
+[NSString stringWithFormat:[[NSBundle mainBundle] localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode, NO) value:@"" table:nil], count]
 
 #define TTTLocalizedPluralStringFromTable(count, singular, tbl, comment) \
 [NSString stringWithFormat:[[NSBundle mainBundle] localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNoun(count, singular) value:@"" table:(tbl)], count]
@@ -39,3 +40,6 @@ extern NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(
 
 #define TTTLocalizedPluralStringWithDefaultValue(count, singular, tbl, bundle, val, comment) \
 [NSString stringWithFormat:[bundle localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNoun(count, singular) value:(val) table:(tbl)], count]
+
+#define TTTUnformattedLocalizedPluralStringFromTableInBundle(count, singular, tbl, bundle, comment) \
+[bundle localizedStringForKey:TTTLocalizedPluralStringKeyForCountAndSingularNounUnformatted(count, singular) value:@"" table:(tbl)]

--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -442,10 +442,15 @@ static NSString * TTTVietnamesePluralRuleForCount(NSUInteger count) {
 
 NSString * TTTLocalizedPluralStringKeyForCountAndSingularNoun(NSUInteger count, NSString *singular) {
     NSString *languageCode = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
-    return TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode);
+    return TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode, YES);
 }
 
-NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInteger count, NSString *singular, NSString *languageCode) {
+NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounUnformatted(NSUInteger count, NSString *singular) {
+    NSString *languageCode = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
+    return TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode, NO);
+}
+
+NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInteger count, NSString *singular, NSString *languageCode, BOOL formatted) {
     NSString *pluralRule = nil;
 
     // Because -hasPrefix is being used here, any three-letter ISO 639-2/3 codes must come before two-letter ISO 639-1 codes in order to prevent, for instance, Konkani (kok) from having Korean (ko) pluralization applied
@@ -522,5 +527,6 @@ NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInte
         return nil;
     }
 
-    return [NSString stringWithFormat:@"%%d %@ (plural rule: %@)", singular, pluralRule];
+    if (! formatted) return [NSString stringWithFormat:@"%@ (plural rule: %@)", singular, pluralRule];
+    else return [NSString stringWithFormat:@"%%d %@ (plural rule: %@)", singular, pluralRule];
 }


### PR DESCRIPTION
when you have a two keys defining pluralization rules "zero" and "one" containing multiple string format specifiers:

keys in your Localizable.strings:
"tour.stop (plural rule: zero)" = "%@ min - %i Stops";
"tour.stop (plural rule: one)" = "%@ min - %i Stop";

to translate with count=0:
```
NSString *localizationKey = TTTUnformattedLocalizedPluralStringFromTableInBundle(count, @"tour.stop", nil, <Your_NSBundle>, nil);
NSString *formattedString = [NSString stringWithFormat:localizationKey, 59, count];
//formatted string: "59 min - 0 Stops"
```
to translate with count=1:
```
NSString *localizationKey = TTTUnformattedLocalizedPluralStringFromTableInBundle(count, @"tour.stop", nil, <Your_NSBundle>, nil);
NSString *formattedString = [NSString stringWithFormat:localizationKey, 59, count];
//formatted string: "59 min - 1 Stop"
```